### PR TITLE
Handle null step definition sets on files when refreshing a step definition source

### DIFF
--- a/src/AutoStep/Definitions/Test/FileStepDefinitionSource.cs
+++ b/src/AutoStep/Definitions/Test/FileStepDefinitionSource.cs
@@ -53,8 +53,12 @@ namespace AutoStep.Definitions.Test
         /// <returns>The set of available definitions.</returns>
         public IEnumerable<StepDefinition> GetStepDefinitions()
         {
-            return File.LastCompileResult?.Output?.StepDefinitions.Select(d => new FileStepDefinition(this, d))
-                   ?? Enumerable.Empty<FileStepDefinition>();
+            if (File.LastCompileResult?.Output?.StepDefinitions is null)
+            {
+                return Enumerable.Empty<FileStepDefinition>();
+            }
+
+            return File.LastCompileResult.Output.StepDefinitions.Select(d => new FileStepDefinition(this, d));
         }
 
         /// <inheritdoc/>

--- a/src/AutoStep/Language/StringContentSource.cs
+++ b/src/AutoStep/Language/StringContentSource.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.IO;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/AutoStep/Language/Test/AutoStepLinker.cs
+++ b/src/AutoStep/Language/Test/AutoStepLinker.cs
@@ -77,7 +77,8 @@ namespace AutoStep.Language.Test
                 trackedSources.Add(stepDefinitionSource.Uid, tracked);
             }
 
-            tracked.UpdateSteps(linkerTree, stepDefinitionSource.GetStepDefinitions());
+            // Load all the step definitions we have.
+            RefreshStepDefinitions(tracked);
         }
 
         /// <summary>

--- a/tests/AutoStep.Tests/Language/EndToEndTests.cs
+++ b/tests/AutoStep.Tests/Language/EndToEndTests.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoStep.Language;
+using AutoStep.Definitions;
+using AutoStep.Execution;
+using AutoStep.Execution.Contexts;
+using AutoStep.Execution.Dependency;
+using AutoStep.Execution.Events;
+using AutoStep.Projects;
+using AutoStep.Tests.Utils;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+using AutoStep.Definitions.Test;
+using System.Threading;
+
+namespace AutoStep.Tests.Language
+{
+    public class EndToEndTests : LoggingTestBase
+    {
+        public EndToEndTests(ITestOutputHelper outputHelper) : base(outputHelper)
+        {
+        }
+
+        [Fact]
+        [Issue("https://github.com/autostep/AutoStep/issues/42")]
+        public async Task RemoveStepDefinitionAfterInitialVersion()
+        {
+            // Compile a file.
+            const string TestFileWithDef =
+            @"                
+              Feature: My Feature
+
+                Scenario: My Scenario
+
+                    When I press 'Add'
+
+               Step: When I press {button}
+
+            "; 
+            
+            const string TestFileWithoutDef =
+             @"                
+              Feature: My Feature
+
+                Scenario: My Scenario
+
+                    When I press 'Add'
+            ";
+
+
+            var project = new Project();
+
+            var source = new UpdatableContentSource(TestFileWithDef);
+
+            var projFile = new ProjectTestFile("/test", source);
+
+            project.TryAddFile(projFile);
+
+            await project.Compiler.CompileAsync(LogFactory);
+
+            project.Compiler.Link();
+
+            projFile.LastLinkResult.Success.Should().BeTrue();
+
+            // First step should have bound.
+            projFile.LastLinkResult.Output.AllStepReferences.First.Value.Binding.Should().NotBeNull();
+
+            // Now update the source to remove the step definition.
+            source.Content = TestFileWithoutDef;
+            source.LastModify = projFile.LastCompileTime.AddSeconds(10);
+
+            await project.Compiler.CompileAsync(LogFactory);
+
+            project.Compiler.Link();
+
+            projFile.LastLinkResult.Success.Should().BeFalse();
+
+            // First step should have bound.
+            projFile.LastLinkResult.Output.AllStepReferences.First.Value.Binding.Should().BeNull();
+        }
+
+        private class UpdatableContentSource : IContentSource
+        {
+            public UpdatableContentSource(string content)
+            {
+                Content = content;
+                LastModify = DateTime.Now;
+            }
+
+            public string SourceName => null;
+
+            public string Content { get; set; }
+
+            public DateTime LastModify { get; set; }
+
+            public ValueTask<string> GetContentAsync(CancellationToken cancelToken = default)
+            {
+                return new ValueTask<string>(Content);
+            }
+
+            public DateTime GetLastContentModifyTime()
+            {
+                return LastModify;
+            }
+        }
+    }
+}

--- a/tests/AutoStep.Tests/Utils/TestStepDefinitionSource.cs
+++ b/tests/AutoStep.Tests/Utils/TestStepDefinitionSource.cs
@@ -31,9 +31,14 @@ namespace AutoStep.Tests.Utils
 
         public bool ConfigureServicesCalled { get; private set; }
 
-        public void AddStepDefinition(StepType type, string declaration)
+        public virtual void AddStepDefinition(StepType type, string declaration)
         {
             defs.Add(new LocalStepDef(this, type, declaration));
+        }
+
+        public virtual void RemoveStepDefinition(StepDefinition def)
+        {
+            defs.Remove(def);
         }
 
         public IEnumerable<StepDefinition> GetStepDefinitions()

--- a/tests/AutoStep.Tests/Utils/UpdatableTestStepDefinitionSource.cs
+++ b/tests/AutoStep.Tests/Utils/UpdatableTestStepDefinitionSource.cs
@@ -5,6 +5,8 @@ namespace AutoStep.Tests.Utils
 {
     public class UpdatableTestStepDefinitionSource : TestStepDefinitionSource, IUpdatableStepDefinitionSource
     {
+        private DateTime lastModifyTime = DateTime.MinValue;
+
         public UpdatableTestStepDefinitionSource(params StepDefinition[] defs) : base(defs)
         {
         }
@@ -15,7 +17,19 @@ namespace AutoStep.Tests.Utils
 
         public DateTime GetLastModifyTime()
         {
-            return DateTime.MinValue;
+            return lastModifyTime;
+        }
+
+        public override void AddStepDefinition(StepType type, string declaration)
+        {
+            base.AddStepDefinition(type, declaration);
+            lastModifyTime = DateTime.UtcNow;
+        }
+
+        public override void RemoveStepDefinition(StepDefinition def)
+        {
+            base.RemoveStepDefinition(def);
+            lastModifyTime = DateTime.UtcNow;
         }
     }
 }


### PR DESCRIPTION
Fixes #42 - Handle a null step definition set when refreshing an existing step definition source